### PR TITLE
Add: update dict of sheets before check

### DIFF
--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -397,6 +397,11 @@ class _OpenpyxlWriter(ExcelWriter):
 
         _style_cache = {}
 
+        # Update sheet list
+        self.sheets = {}
+        for wks in self.book.worksheets:
+            self.sheets[wks.title] = wks
+
         if sheet_name in self.sheets:
             wks = self.sheets[sheet_name]
         else:


### PR DESCRIPTION
```python
import pandas as pd

df = pd.DataFrame(
    {
        "id": ["1", "2", "3", "4", "5"],
        "Feature1": ["A", "C", "E", "G", "I"],
        "Feature2": ["B", "D", "F", "H", "J"],
    },
    columns=["id", "Feature1", "Feature2"],
)
writer = pd.ExcelWriter(path="testOutput.xlsx", mode="a", engine="openpyxl")
df.to_excel(writer, sheet_name="Main")
writer.save()
writer.close()
```
#### Problem description

I have excel file with existing sheet "Main", and if I try to append some dataframe to this sheet, on first df.to_excel() pandas creates new sheet with name "Main1" and saves information to this new sheet. But if once to_excel(), than pandas add new sheet to dictionary and saves to existing sheet. So, on start appen pandas don't know nothing about existing sheets, and check in **_openpyxl.py** file don't realy work
```python
        if sheet_name in self.sheets:
            wks = self.sheets[sheet_name]
        else:
            wks = self.book.create_sheet()
            wks.title = sheet_name
            self.sheets[sheet_name] = wks
```
so I add new code to update sheetname-list before check.